### PR TITLE
Prompt for new and old policy settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,20 @@ Have your [OX Token](#getting-your-ox-token) and
 
 `deno run -A ox-policy-settings-updater.ts`
 
-The script is preset to enable "monitor" status on _all_ policies, for both old
-and new issues, for the given application.
-
-To change the presets, update the `policySettingsInput` constant in the `main()`
-function (starting at about line 205).
+The script will prompt for new and old policy settings to be applied and then
+set the same status for _all_ such policies, for the given application.
 
 ## Additional materials
+
 The JSON files are included as a convenience to understand the bare APIs being
-used. Load the query and variables into your chosen GraphQL capable client, along
-with an authorization token and appId, and submit them to the 
+used. Load the query and variables into your chosen GraphQL capable client,
+along with an authorization token and appId, and submit them to the
 `https://api.cloud.ox.security/api/policy-service` endpoint.
 
 ##### Getting your OX Token
 
 Login to the [OX Dashboard](https://app.ox.security) and bring up your browser's
-Developer Tools (usually `ctrl-shift-I` or `cmd-opt-I` depending on your
-platform).
+Developer Tools (`ctrl-shift-I` or `cmd-opt-I` depending on your platform).
 
 From there, go to the "Network" tab and filter the traffic for
 `api.cloud.ox.security` (refresh the page if necessary) and from the Request
@@ -39,9 +36,9 @@ encoding for "{" which all JWTs start with).
 
 ##### Getting the Application Id
 
-Of course there's an API way, but for simplicity, try this browser-based method.
-Navigate to the application, select it, and in your location bar, note the query
-parameter `appId` . For instance,
+While there is an API way, for simplicity, try this browser-based method.
+Navigate to the application, select it, and in your browser's location bar, note
+the query parameter `appId` . For instance,
 `https://app.ox.security/applications?appId=353737035`. Selecting a different
 row will update which application is highlighted and therefore which appId is
 referenced in the URL's query parameter.

--- a/ox-policy-settings-updater.ts
+++ b/ox-policy-settings-updater.ts
@@ -74,11 +74,11 @@ async function getPolicySettings(
   };
 
   try {
-/*    console.log(
+    /*    console.log(
       "Making request with variables:",
       JSON.stringify(variables, null, 2),
     );
-*/
+    */
     const response = await fetch(
       "https://api.cloud.ox.security/api/policy-service",
       {
@@ -157,11 +157,11 @@ async function setPolicySettings(
     );
 
     const jsonResponse = await response.json();
-/*    console.log(
+    /*    console.log(
       "Raw GraphQL Mutation Response:",
       JSON.stringify(jsonResponse, null, 2),
     );
-*/
+    */
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -189,7 +189,9 @@ async function promptForAppId(): Promise<string[]> {
   return [appId];
 }
 
-async function promptForPolicyOption(promptMessage: string): Promise<PolicyOption> {
+async function promptForPolicyOption(
+  promptMessage: string,
+): Promise<PolicyOption> {
   const userInput = prompt(promptMessage)?.toLowerCase();
 
   if (!userInput) {
@@ -255,7 +257,7 @@ async function main() {
     }, authToken);
 
     console.log("Policy settings update complete.");
-//    console.log("Modified settings:", result);
+    //    console.log("Modified settings:", result);
   } catch (error) {
     console.error("Error in main process:", error);
     if (error instanceof Error) {

--- a/ox-policy-settings-updater.ts
+++ b/ox-policy-settings-updater.ts
@@ -35,6 +35,15 @@ interface SetPolicySettingsResponse {
   };
 }
 
+// New type for policy options
+type PolicyOption = "block" | "monitor" | "disable";
+
+const POLICY_OPTION_IDS: Record<PolicyOption, string> = {
+  block: "1",
+  monitor: "2",
+  disable: "3",
+};
+
 async function promptForToken(): Promise<string> {
   const token = prompt("Please enter your authorization token:") ?? "";
   if (!token) {
@@ -65,11 +74,11 @@ async function getPolicySettings(
   };
 
   try {
-    console.log(
+/*    console.log(
       "Making request with variables:",
       JSON.stringify(variables, null, 2),
     );
-
+*/
     const response = await fetch(
       "https://api.cloud.ox.security/api/policy-service",
       {
@@ -86,7 +95,7 @@ async function getPolicySettings(
     );
 
     const jsonResponse = await response.json();
-    console.log("Raw GraphQL Response:", JSON.stringify(jsonResponse, null, 2));
+    //console.log("Raw GraphQL Response:", JSON.stringify(jsonResponse, null, 2));
 
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
@@ -109,7 +118,7 @@ async function getPolicySettings(
       [],
     );
 
-    console.log(`Found ${allSettings.length} total policy settings`);
+    //console.log(`Found ${allSettings.length} total policy settings`);
     return allSettings;
   } catch (error) {
     console.error("Error fetching policy settings:", error);
@@ -148,11 +157,11 @@ async function setPolicySettings(
     );
 
     const jsonResponse = await response.json();
-    console.log(
+/*    console.log(
       "Raw GraphQL Mutation Response:",
       JSON.stringify(jsonResponse, null, 2),
     );
-
+*/
     if (!response.ok) {
       throw new Error(`HTTP error! status: ${response.status}`);
     }
@@ -180,6 +189,22 @@ async function promptForAppId(): Promise<string[]> {
   return [appId];
 }
 
+async function promptForPolicyOption(promptMessage: string): Promise<PolicyOption> {
+  const userInput = prompt(promptMessage)?.toLowerCase();
+
+  if (!userInput) {
+    throw new Error("Policy setting is required");
+  }
+
+  if (!["block", "monitor", "disable"].includes(userInput)) {
+    throw new Error(
+      "Invalid policy setting. Please choose 'block', 'monitor', or 'disable'",
+    );
+  }
+
+  return userInput as PolicyOption;
+}
+
 async function main() {
   try {
     // Prompt for authorization token
@@ -198,12 +223,20 @@ async function main() {
 
     console.log(`Retrieved ${policySettings.length} policy settings`);
 
+    // Prompt for policy options
+    console.log("Choose policy settings for new and existing issues");
+    const newIssuesOption = await promptForPolicyOption(
+      "Please choose a policy setting for NEW issues (block/monitor/disable):",
+    );
+    const oldIssuesOption = await promptForPolicyOption(
+      "Please choose a policy setting for EXISTING issues (block/monitor/disable):",
+    );
+
     // Create policy settings input array
-    // block: 1, monitor: 2, disable: 3
     const policySettingsInput: PolicySettingInput[] = policySettings.map(
       (setting) => ({
-        newOptionId: "2",
-        oldOptionId: "2",
+        newOptionId: POLICY_OPTION_IDS[newIssuesOption],
+        oldOptionId: POLICY_OPTION_IDS[oldIssuesOption],
         policyId: setting.policyId,
       }),
     );
@@ -211,8 +244,10 @@ async function main() {
     // Set policy settings for each policy ID
     console.log("Setting policy settings...");
     console.log(
-      `Preparing to update ${policySettingsInput.length} policy settings`,
+      `Preparing to update ${policySettingsInput.length} policy settings:`,
     );
+    console.log(`- New issues: "${newIssuesOption}" mode`);
+    console.log(`- Existing issues: "${oldIssuesOption}" mode`);
 
     const result = await setPolicySettings({
       appIds: appIdArray,
@@ -220,7 +255,7 @@ async function main() {
     }, authToken);
 
     console.log("Policy settings update complete.");
-    console.log("Modified settings:", result);
+//    console.log("Modified settings:", result);
   } catch (error) {
     console.error("Error in main process:", error);
     if (error instanceof Error) {


### PR DESCRIPTION
Instead of asking the user to update the hard-coded values, prompt for them. Separate New and Old (named Existing in the prompt).